### PR TITLE
Invalid operands to binary operator

### DIFF
--- a/utils/eye4graphics.cc
+++ b/utils/eye4graphics.cc
@@ -568,9 +568,9 @@ int findNextColor(BoundingBox* bbox,
                 bbox->right = x;
                 bbox->top = y;
                 bbox->bottom = y;
-                bbox->error = (((hay_pixel.red & 0xff) << 16) +
-                               ((hay_pixel.green & 0xff) << 8) +
-                               (hay_pixel.blue & 0xff));
+                bbox->error = ((((int) hay_pixel.red & 0xff) << 16) +
+                               (((int) hay_pixel.green & 0xff) << 8) +
+                               ((int) hay_pixel.blue & 0xff));
                 return 1;
             }
         }


### PR DESCRIPTION
The compilation of the project fails with an error of invalid operands of types ‘const Quantum {aka const float}’ and ‘int’ to binary ‘operator&’ in eye4graphics.cc. By casting the pixel values this issue is ressolved.