### PR TITLE
Trivial fixes for compiler warnings

### DIFF
--- a/src/adapter_remote.cc
+++ b/src/adapter_remote.cc
@@ -133,7 +133,6 @@ void Adapter_remote::execute(std::vector<int>& action)
   char* s = NULL;
   size_t si = 0;
   int e;
-  char* read_buf=NULL;
 
   fprintf(d_stdin, "%i\n", action[0]);
 

--- a/src/coverage_prop.cc
+++ b/src/coverage_prop.cc
@@ -58,7 +58,6 @@ bool Coverage_Prop::execute(int action)
 {
   int* pro;
   int cnt=model->getprops(&pro);
-  int already_seen=0;
 
   for(int i=0;i<cnt;i++) {
     if (prop_included[pro[i]] && !data[pro[i]]) {

--- a/src/end_condition.cc
+++ b/src/end_condition.cc
@@ -80,8 +80,10 @@ std::string End_condition::stringify() {
     break;
   case ACTION:
     name="ACTION";
+    break;
   case STATUS:
     name="STATUS";
+    break;
   default:
     return "";
   }

--- a/src/remote_adapter_loader.cc
+++ b/src/remote_adapter_loader.cc
@@ -17,7 +17,9 @@
  *
  */
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 
 #include <cstdio>
 #include <sys/types.h>


### PR DESCRIPTION
I compiled fMBT using Clang and g++ with a lot of warnings turned on as
errors and made a few fixes to get things to build in those
configurations. The fixes are:
 - Removal of two unused variables
 - Define _GNU_SOURCE only if it is not already defined. (Apparently
   g++ already defines this automatically and complains if it is redefined:
   http://stackoverflow.com/questions/559440/getline-in-c-gnu-source-not-needed)
 - Added missing breaks to a switch statement. It looks like the case
   fallthrough for ACTION and STATUS is not intended, so this fix
   should make the behavior correct for those cases.