### PR TITLE
Fixed vector indexing out of range

### DIFF
--- a/src/aalang_cpp.cc
+++ b/src/aalang_cpp.cc
@@ -488,7 +488,11 @@ std::string aalang_cpp::stringify()
       "\t\ttags.push_back("+to_string(i)+");\n"
       "\t}\n";
   }
-  s=s+"\t*props = &tags[0];\n"
+  s=s+"\tif (tags.empty()) {\n"
+    "\t\t*props = NULL;\n"
+    "\t} else {\n"
+    "\t\t*props = &tags[0];\n"
+    "\t}\n"
     "\treturn tags.size();\n"
     "}\n"
     "};\n";

--- a/src/test_engine.cc
+++ b/src/test_engine.cc
@@ -184,7 +184,9 @@ void Test_engine::verify_tags(const std::vector<std::string>& tnames)
   }
 
   cnt=t.size();
-  tags=&t[0];
+  if (!t.empty()) {
+    tags=&t[0];
+  }
 
   if (cnt) {
     adapter.check_tags(tags,cnt,mismatch_tags);


### PR DESCRIPTION
This fixes two places where the code tries to index into an empty vector
when operating on a configuration that does not have any tags. I think
the way the code is written it usually works in practice but is
undefined behavior. This commit changes the code so that it does not
even take the address of the first element of the vector unless the
vector is non-empty.

Here is the resulting diff of the generated mycountertest.cc file from
examples/c++-unittest:

--- mycountertest-old.cc	2015-07-25 19:22:29.775713236 -0700
+++ mycountertest-new.cc	2015-07-25 19:23:03.008128216 -0700
@@ -236,7 +236,11 @@
 }
 virtual int getprops(int** props) {
 	tags.clear();
-	*props = &tags[0];
+	if (tags.empty()) {
+		*props = NULL;
+	} else {
+		*props = &tags[0];
+	}
 	return tags.size();
 }
 };