### PR TITLE
Visual log improvements

### DIFF
--- a/utils/fmbtgti.py
+++ b/utils/fmbtgti.py
@@ -3135,7 +3135,7 @@ function hideChildLists(eid) {
       //If the function has a parent function call
       if (parentFunctionCallElement.length > 0){
          parentFunctionCallElement.css("color", "blue");
-         parentFunctionCallElement.on("click", function(event) {
+         parentFunctionCallElement.unbind("click").bind("click", function(event) {
             $(event.currentTarget).parent().parent().find("ul.depth_" + (element_depth).toString()).toggle();
          });
          $(parentFunctionCallElement).parent().parent().find("ul.depth_" + (element_depth).toString()).hide();
@@ -3285,6 +3285,7 @@ else {
         left: 20px;
         width: 180px;
         color: red;
+        z-index: 0;
     }
 </style>
 </head><body>


### PR DESCRIPTION
The visual log screenshots can now be enlarged by hovering the mouse over them. Also, in case the screenshot is older than 0.3 seconds, the age will be overlaid on the screenshot.

0.3 seconds seemed to be a reasonable amount of time in terms of not printing the age unnecessarily for brand new images. Then again, if the screenshot is older than 0.3 seconds, it's probably because you're doing some tapping/swiping, and fMBT just draws the "highlights" on top of the old screenshot. In which case printing out the age is beneficial.