### PR TITLE
Build Windows installer using Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:21
+run yum -y install git
+run git clone https://github.com/01org/fMBT.git
+run cd fMBT;./build-fMBT-installer-winXX.exe.sh 32

--- a/docker/build_fmbt_windows_docker.sh
+++ b/docker/build_fmbt_windows_docker.sh
@@ -1,0 +1,9 @@
+mkdir -p build-win32
+docker build -t fmbt_fedora .
+docker run -i -v ${PWD}/build-win32:/build-win32 fmbt_fedora sh << COMMANDS
+echo Copying build binaries to host
+cp fMBT/build-win32/*.exe /build-win32
+cp fMBT/build-win32/*.msi /build-win32
+echo Changing owner from \$(id -u):\$(id -g) to $(id -u):$(id -u)
+chown -R $(id -u):$(id -u) /build-win32
+COMMANDS


### PR DESCRIPTION
precondition: Docker is installed and is able to get
images from Docker Hub.

See http://docs.docker.com/linux/started/ for details.

Dockerfile pulls down fedora:21 and uses that to
build Windows 32 installer.

build_fmbt_windows_docker.sh automates building of the
Docker image and copying of build binaries to the host side

Signed-off-by: Jukka Laukkanen <jukkalau@gmail.com>