### PR TITLE
Map coordinates to the whole desktop to support multiple monitors

### DIFF
--- a/utils/fmbtwindows_agent.py
+++ b/utils/fmbtwindows_agent.py
@@ -794,7 +794,7 @@ def sendMouseUp(button=1):
     return sendInput(event)
 
 def sendMouseMove(x, y, button=1):
-    flags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE
+    flags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK
     x = x * 65535 /_mouse_input_area[0]
     y = y * 65535 /_mouse_input_area[1]
     event = Mouse(flags, x, y, 0)


### PR DESCRIPTION
At the moment on Windows fMBT gets the available mouse input area from the whole virtual desktop but the sendMouseMove function maps the coordinates only to the primary monitor. This additional flag fixes that.